### PR TITLE
Improve list parser

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -86,6 +86,10 @@ spec = do
     $ it "quoted list"
     $ ("\"one\"\n two\n three3" :: Text) ~> parseList 1
       `shouldParse` ["one", "two", "three3"]
+  describe "Should Succeed"
+    $ it "list with leading commas"
+    $ ("one\n , two\n , three3" :: Text) ~> parseList 1
+      `shouldParse` ["one", "two", "three3"]
 
 exeSection :: Text
 exeSection =


### PR DESCRIPTION
Current parser for lists, like `packages:` in `cabal.project.local`,
fails to process some input, for example:

packages:
    foo/foo.cabal
  , bar/bar.cabal
  , baz/baz.cabal

This commit simplifies the parser by using `sepBy` directly and by
handling indented fields more uniformly.