### PR TITLE
Replace custom `dropLast` function with standard `init` function

### DIFF
--- a/src/Hie/Yaml.hs
+++ b/src/Hie/Yaml.hs
@@ -50,11 +50,8 @@ fmtComponent (p, c) =
     <> "component: "
     <> dQuote c
 
-dropLast :: [a] -> [a]
-dropLast l = take (length l - 1) l
-
 fmtPkgs :: String -> [Package] -> String
-fmtPkgs sOrC pkgs = dropLast $ unlines l
+fmtPkgs sOrC pkgs = init $ unlines l
   where
     comp = if sOrC == "cabal" then cabalComponent else stackComponent
     f (Package n cs) = map ((<> "\n") . fmtComponent . comp n) cs


### PR DESCRIPTION
Hi,

I'm a beginner in Haskell and I noticed that you created a function 'dropLast' that is basically the same as the core function 'init'.

This PR remove the custom function 'dropLast' and uses 'init'.

Link: https://hackage.haskell.org/package/base-4.14.0.0/docs/Prelude.html#v:init