### PR TITLE
Add note about why custom function dropLast is used

### DIFF
--- a/src/Hie/Yaml.hs
+++ b/src/Hie/Yaml.hs
@@ -50,7 +50,7 @@ fmtComponent (p, c) =
     <> "component: "
     <> dQuote c
 
--- Same as init but handle empty list without throwing errors.
+-- | Same as init but handle empty list without throwing errors.
 dropLast :: [a] -> [a]
 dropLast l = take (length l - 1) l
 

--- a/src/Hie/Yaml.hs
+++ b/src/Hie/Yaml.hs
@@ -50,6 +50,7 @@ fmtComponent (p, c) =
     <> "component: "
     <> dQuote c
 
+-- Same as init but handle empty list without throwing errors.
 dropLast :: [a] -> [a]
 dropLast l = take (length l - 1) l
 


### PR DESCRIPTION
Add a note about why dropLast is used instead of init.

Follows #18 