### PR TITLE
Update dropLast function

### DIFF
--- a/src/Hie/Yaml.hs
+++ b/src/Hie/Yaml.hs
@@ -52,7 +52,9 @@ fmtComponent (p, c) =
 
 -- | Same as init but handle empty list without throwing errors.
 dropLast :: [a] -> [a]
-dropLast l = take (length l - 1) l
+dropLast xs
+    | null xs   = []
+    | otherwise = init xs
 
 fmtPkgs :: String -> [Package] -> String
 fmtPkgs sOrC pkgs = dropLast $ unlines l


### PR DESCRIPTION
Update `dropLast` function, handle empty list otherwise use the core `init` function.

Follows: #19 #18 

Credits: @enikar on #haskell-fr