### PR TITLE
Add `executable` flag to toggle building the executable

### DIFF
--- a/implicit-hie.cabal
+++ b/implicit-hie.cabal
@@ -62,7 +62,7 @@ library
   default-language: Haskell2010
 
 flag executable
-  descritption: Build the gen-hie executable
+  description: Build the gen-hie executable
   default: True
 
 executable gen-hie

--- a/implicit-hie.cabal
+++ b/implicit-hie.cabal
@@ -61,6 +61,10 @@ library
 
   default-language: Haskell2010
 
+flag executable
+  descritption: Build the gen-hie executable
+  default: True
+
 executable gen-hie
   main-is:          Main.hs
   other-modules:    Paths_implicit_hie
@@ -84,6 +88,9 @@ executable gen-hie
     , yaml
 
   default-language: Haskell2010
+  
+  if !flag(executable)
+    buildable: False
 
 test-suite implicit-hie-test
   type:             exitcode-stdio-1.0


### PR DESCRIPTION
This package is a transient dependency of [haskell-language-server][1].
However, only the library is needed. This flag gives the option for those
who do not need the executable to disable it.

The flag is enabled by default.

[1]: https://hackage.haskell.org/package/haskell-language-server