### PR TITLE
Provide help message.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -35,9 +35,13 @@ resolveName pwd = do
   files <- listDirectory pwd
   when ("--help" `elem` args || "-h" `elem` args) $ do
     progName <- getProgName
-    hPutStrLn stderr $ "Usage: " <> progName <> " [ --cabal | --stack ]\n\n\
-      \If neither argument is given then " <> progName <> " will infer the type by\n\
-      \looking for dist-newstyle, .stack-work, cabal.project and stack.yaml in that order."
+    hPutStrLn stderr $
+      "Usage: " <> progName
+        <> " [ --cabal | --stack ]\n\n\
+           \If neither argument is given then "
+        <> progName
+        <> " will infer the type by\n\
+           \looking for dist-newstyle, .stack-work, cabal.project and stack.yaml in that order."
     exitSuccess
   let fileNames = map takeFileName files
       name =

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -9,7 +9,9 @@ import Hie.Locate
 import Hie.Yaml
 import System.Directory
 import System.Environment
+import System.Exit
 import System.FilePath.Posix
+import System.IO
 
 main :: IO ()
 main = do
@@ -19,7 +21,7 @@ main = do
     "cabal" -> cabalPkgs pwd
     _ -> stackYamlPkgs pwd
   when (null cfs) $
-    error $
+    die $
       "Used" <> name
         <> "\n No .cabal files found under"
         <> pwd
@@ -31,6 +33,12 @@ resolveName :: FilePath -> IO String
 resolveName pwd = do
   args <- getArgs
   files <- listDirectory pwd
+  when ("--help" `elem` args || "-h" `elem` args) $ do
+    progName <- getProgName
+    hPutStrLn stderr $ "Usage: " <> progName <> " [ --cabal | --stack ]\n\n\
+      \If neither argument is given then " <> progName <> " will infer the type by\n\
+      \looking for dist-newstyle, .stack-work, cabal.project and stack.yaml in that order."
+    exitSuccess
   let fileNames = map takeFileName files
       name =
         if

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -22,7 +22,7 @@ main = do
     _ -> stackYamlPkgs pwd
   when (null cfs) $
     die $
-      "Used" <> name
+      "Used " <> name
         <> "\n No .cabal files found under"
         <> pwd
         <> "\n You may need to run stack build."


### PR DESCRIPTION
If `-h` or `--help` is given this prints a useful message and exits.