### PR TITLE
Use Cabal-syntax to parse cabal packages

### DIFF
--- a/implicit-hie.cabal
+++ b/implicit-hie.cabal
@@ -46,15 +46,16 @@ library
   hs-source-dirs:   src
   ghc-options:
     -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns
-    -fno-warn-unused-imports -fno-warn-unused-binds
     -fno-warn-name-shadowing -fwarn-redundant-constraints
 
   build-depends:
       attoparsec    >=0.13
     , base          >=4.7  && <5
+    , bytestring
     , directory     >=1.3
     , filepath      >=1.4
     , filepattern   >=0.1
+    , Cabal-syntax  >=3.8
     , text          >=1.2
     , transformers  >=0.5
     , yaml          >=0.5
@@ -88,7 +89,7 @@ executable gen-hie
     , yaml
 
   default-language: Haskell2010
-  
+
   if !flag(executable)
     buildable: False
 

--- a/src/Hie/Cabal/Parser.hs
+++ b/src/Hie/Cabal/Parser.hs
@@ -15,7 +15,8 @@ import           Control.Monad
 import           Data.Attoparsec.Text
 import           Data.Char
 import           Data.Foldable                                 (asum)
-import           Data.Maybe                                    (maybeToList, catMaybes)
+import           Data.Maybe                                    (catMaybes,
+                                                                maybeToList)
 import           Data.Text                                     (Text)
 import qualified Data.Text                                     as T
 import           Data.Text.Encoding                            (encodeUtf8)
@@ -23,15 +24,17 @@ import           Distribution.ModuleName                       (ModuleName,
                                                                 toFilePath)
 import           Distribution.Package                          (pkgName,
                                                                 unPackageName)
-import           Distribution.PackageDescription               (Benchmark (benchmarkBuildInfo, benchmarkName, benchmarkInterface),
+import           Distribution.PackageDescription               (Benchmark (benchmarkBuildInfo, benchmarkInterface, benchmarkName),
+                                                                BenchmarkInterface (BenchmarkExeV10),
                                                                 Executable (buildInfo, exeName, modulePath),
                                                                 ForeignLib (foreignLibBuildInfo, foreignLibName),
                                                                 Library (libBuildInfo, libName),
                                                                 LibraryName (..),
+                                                                TestSuiteInterface (TestSuiteExeV10),
                                                                 benchmarkModules,
                                                                 exeModules,
                                                                 explicitLibModules,
-                                                                foreignLibModules, TestSuiteInterface (TestSuiteExeV10), BenchmarkInterface (BenchmarkExeV10))
+                                                                foreignLibModules)
 import           Distribution.PackageDescription.Configuration
 import           Distribution.PackageDescription.Parsec
 import           Distribution.Types.BuildInfo
@@ -39,9 +42,9 @@ import           Distribution.Types.PackageDescription
 import           Distribution.Types.TestSuite
 import           Distribution.Types.UnqualComponentName
 import           Distribution.Utils.Path                       (getSymbolicPath)
-import           System.FilePath                               ((</>), (<.>))
-import GHC.IO (unsafePerformIO)
-import System.Directory (doesFileExist)
+import           GHC.IO                                        (unsafePerformIO)
+import           System.Directory                              (doesFileExist)
+import           System.FilePath                               ((<.>), (</>))
 
 
 type Name = Text
@@ -172,7 +175,7 @@ extractPackage PackageDescription{..} = Package n cc where
 benchmarkExePath :: Benchmark -> [FilePath]
 benchmarkExePath b = case benchmarkInterface b of
   BenchmarkExeV10 _ f -> [f]
-  _ -> []
+  _                   -> []
 
 toFilePath' :: ModuleName -> [FilePath]
 toFilePath' mod = [ toFilePath mod <.> ext | ext <- ["hs", "lhs"]]
@@ -180,4 +183,4 @@ toFilePath' mod = [ toFilePath mod <.> ext | ext <- ["hs", "lhs"]]
 testExePath :: TestSuite -> [FilePath]
 testExePath t = case testInterface t of
     TestSuiteExeV10 _ fp -> [fp]
-    _ -> []
+    _                    -> []

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -14,212 +14,31 @@ main = hspec spec
 spec :: Spec
 spec = do
   describe "Should Succeed" $
-    it "successfully parses executable section" $
-      exeSection ~> parseExe 0
-        `shouldParse` [Comp Exe "gen-hie" "app/Main.hs"]
-  describe "Should Succeed" $
-    it "successfully parses test section" $
-      testSection ~> parseTestSuite 0
-        `shouldParse` [Comp Test "implicit-hie-test" "test"]
-  describe "Should Succeed" $
-    it "successfully parses library section" $
-      libSection ~> parseLib 0
-        `shouldParse` [Comp Lib "" "src"]
-  describe "Should Succeed" $
-    it "successfully parses library section with 2 hs-source-dirs" $
-      libSection2 ~> parseLib 0
-        `shouldParse` [Comp Lib "" "src", Comp Lib "" "src2"]
-  describe "Should Succeed" $
-    it "successfully parses library section with 2 paths under hs-source-dirs" $
-      libSection3 ~> parseLib 0
-        `shouldParse` [Comp Lib "" "src", Comp Lib "" "src2"]
-  describe "Should Succeed" $
-    it "successfully parses bench section" $
-      do
-        bs <- T.readFile "test/benchSection"
-        bs ~> parseBench 0
-          `shouldParse` [Comp Bench "folds" "benchmarks/folds.hs"]
-  describe "Should Succeed" $
     it "successfully parses package" $
       do
         cf <- T.readFile "implicit-hie.cabal"
-        cf ~> parsePackage
+        parsePackage' cf
           `shouldParse` Package
             "implicit-hie"
-            [ Comp Lib "" "src",
+            [ Comp Test "implicit-hie-test" "test/Spec.hs",
               Comp Exe "gen-hie" "app/Main.hs",
-              Comp Test "implicit-hie-test" "test"
+              Comp Lib "" "src/Hie/Cabal/Parser.hs",
+              Comp Lib "" "src/Hie/Locate.hs",
+              Comp Lib "" "src/Hie/Yaml.hs"
             ]
-  describe "Should Succeed" $
-    it
-      "skips to end of block section"
-      $ let r = "test\n"
-         in (libSection <> r) ~?> parseLib 0
-              `leavesUnconsumed` r
+
   describe "Should Succeed" $
     it "successfully generates stack hie.yaml" $
       do
         sf <- readFile "test/stackHie.yaml"
         cf <- T.readFile "implicit-hie.cabal"
-        (hieYaml "stack" . fmtPkgs "stack" . (: []) <$> parseOnly parsePackage cf)
+        (hieYaml "stack" . fmtPkgs "stack" . (: []) <$> parsePackage' cf)
           `shouldBe` Right sf
+
   describe "Should Succeed" $
     it "successfully generates cabal hie.yaml for haskell-language-server" $
       do
         f <- T.readFile "test/haskell-language-server-cabal"
         o <- readFile "test/hie.yaml.cbl"
-        (hieYaml "cabal" . fmtPkgs "cabal" . (: []) <$> parseOnly parsePackage f)
+        (hieYaml "cabal" . fmtPkgs "cabal" . (: []) <$> parsePackage' f)
           `shouldBe` Right o
-  describe "Should Succeed" $
-    it "successfully parses comma list" $
-      ("one, two" :: Text) ~> parseList 1 `shouldParse` ["one", "two"]
-  describe "Should Succeed" $
-    it "successfully parses newline list" $
-      ("one\n two \n three3" :: Text) ~> parseList 1
-        `shouldParse` ["one", "two", "three3"]
-  describe "Should Succeed" $
-    it "successfully parses newline comma list" $
-      ("one\n two,  three3" :: Text) ~> parseList 1
-        `shouldParse` ["one", "two", "three3"]
-  describe "Should Succeed" $
-    it "quoted list" $
-      ("\"one\"\n two\n three3" :: Text) ~> parseList 1
-        `shouldParse` ["one", "two", "three3"]
-  describe "Should Succeed" $
-    it "list with leading commas" $
-      ("one\n , two\n , three3" :: Text) ~> parseList 1
-        `shouldParse` ["one", "two", "three3"]
-  describe "Should Succeed" $
-    it "list with a comment" $
-      ("foo\n  -- need to include this too\n  bar\n" :: Text) ~> parseList 1
-        `shouldParse` ["foo", "bar"]
-  describe "Should Succeed" $
-    it "list2 with a comment" $
-      ("foo  -- need to include this too\n  bar\n" :: Text) ~> parseList 1
-        `shouldParse` ["foo", "bar"]
-  describe "Should Succeed" $
-    it "list3 with a comment" $
-      ("foo  -- need to include this too\n  bar" :: Text) ~> parseList 1
-        `shouldParse` ["foo", "bar"]
-  describe "Should Succeed" $
-    it "list4 with a comment" $
-      ("foo\n bar\n  -- need to include this too" :: Text) ~> parseList 1
-        `shouldParse` ["foo", "bar"]
-  describe "Should Succeed" $
-    it "list5 with a comment" $
-      ("foo\n bar -- need to include this too" :: Text) ~> parseList 1
-        `shouldParse` ["foo", "bar"]
-  describe "Should Succeed" $
-    it "succesfully parses exe component with other-modules containing dots" $
-      exeSection2 ~> parseExe 0
-        `shouldParse` [ Comp Exe "gen-hie" "app/Main.hs",
-                        Comp Exe "gen-hie" "app/Hie/Executable/Helper.hs",
-                        Comp Exe "gen-hie" "app/Hie/Executable/Utils.hs"
-                      ]
-  describe "Should Succeed" $
-    it "succesfully parses single other-modules" $
-      ("other-modules: test\ndefault-language:   Haskell2011" :: Text) ~?> field 0 "other-modules" parseList
-        `leavesUnconsumed` "default-language:   Haskell2011"
-  describe "Should Succeed" $
-    it "succesfully parses empty other-modules1" $
-      ("other-modules: test\ndefault-language:   Haskell2011" :: Text) ~?> field 0 "other-modules" parseList
-        `leavesUnconsumed` "default-language:   Haskell2011"
-  describe "Should Succeed" $
-    it "succesfully parses empty other-modules2" $
-      ("    other-modules: \n    build-depends:\n        base >=4.9 && <5" :: Text) ~> field 0 "other-modules" parseList
-        `shouldParse` []
-
-exeSection :: Text
-exeSection =
-  "executable gen-hie\n\
-  \  other-modules:\n\
-  \    Paths_implicit_hie\n\
-  \  autogen-modules:\n\
-  \    Paths_implicit_hie\n\
-  \  hs-source-dirs:\n\
-  \      app\n\
-  \  ghc-options: -O2\n\
-  \  main-is: Main.hs \n"
-
-testSection :: Text
-testSection =
-  "test-suite implicit-hie-test\n\
-  \  type: exitcode-stdio-1.0\n\
-  \  other-modules:\n\
-  \      Paths_implicit_hie\n\
-  \  hs-source-dirs:\n\
-  \      test\n\
-  \  ghc-options: -fspecialize-aggressively -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns -fno-warn-unused-imports -fno-warn-unused-binds -fno-warn-name-shadowing -fwarn-redundant-constraints -threaded -rtsopts -with-rtsopts=-N\n\
-  \  main-is: Spec.hs\n\
-  \  build-depends:\n\
-  \      attoparsec\n\
-  \    , base >=4.7 && <5\n\
-  \    , hspec\n\
-  \    , hspec-attoparsec\n\
-  \    , implicit-hie\n\
-  \    , text\n\
-  \  default-language: Haskell2010\n"
-
-libSection :: Text
-libSection =
-  "library\n\
-  \  exposed-modules:\n\
-  \  Lib\n\
-  \  other-modules:\n\
-  \    Paths_implicit_hie\n\
-  \  hs-source-dirs:\n\
-  \    src\n\
-  \  ghc-options: -fspecialize-aggressively -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns -fno-warn-unused-imports -fno-warn-unused-binds -fno-warn-name-shadowing -fwarn-redundant-constraints\n\
-  \  build-depends:\n\
-  \    attoparsec\n\
-  \  , base >=4.7 && <5\n\
-  \  , text\n\
-  \  default-language: Haskell2010\n\
-  \"
-
-libSection2 :: Text
-libSection2 =
-  "library\n\
-  \  exposed-modules:\n\
-  \  Lib\n\
-  \  other-modules:\n\
-  \  Paths_implicit_hie\n\
-  \  hs-source-dirs:\n\
-  \    src\n\
-  \  hs-source-dirs:\n\
-  \   src2\n\
-  \  ghc-options: -fspecialize-aggressively -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns -fno-warn-unused-imports -fno-warn-unused-binds -fno-warn-name-shadowing -fwarn-redundant-constraints\n\
-  \  build-depends:\n\
-  \  attoparsec\n\
-  \  , base >=4.7 && <5\n\
-  \  , text\n\
-  \  default-language: Haskell2010\n\
-  \"
-
-libSection3 :: Text
-libSection3 =
-  "library\n\
-  \  exposed-modules:\n\
-  \  Lib\n\
-  \  other-modules:\n\
-  \  Paths_implicit_hie\n\
-  \  hs-source-dirs:\n\
-  \   src,\n\
-  \   src2\n\
-  \  ghc-options: -fspecialize-aggressively -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns -fno-warn-unused-imports -fno-warn-unused-binds -fno-warn-name-shadowing -fwarn-redundant-constraints\n\
-  \  build-depends:\n\
-  \  attoparsec\n\
-  \  , base >=4.7 && <5\n\
-  \  , text\n\
-  \  default-language: Haskell2010\n\
-  \"
-
-exeSection2 :: Text
-exeSection2 =
-  "executable gen-hie\n\
-  \  other-modules:\n\
-  \    Hie.Executable.Helper\n\
-  \    Hie.Executable.Utils\n\
-  \  hs-source-dirs:\n\
-  \      app\n\
-  \  main-is: Main.hs \n"

--- a/test/benchSection
+++ b/test/benchSection
@@ -1,3 +1,6 @@
+name:               folds-test
+version:            0.1
+
 benchmark folds
   default-language: Haskell2010
   hs-source-dirs:   benchmarks

--- a/test/hie.yaml.cbl
+++ b/test/hie.yaml.cbl
@@ -1,22 +1,2 @@
 cradle:
   cabal:
-    - path: "src"
-      component: "lib:haskell-language-server"
-
-    - path: "exe/Main.hs"
-      component: "haskell-language-server:exe:haskell-language-server"
-
-    - path: "exe/Arguments.hs"
-      component: "haskell-language-server:exe:haskell-language-server"
-
-    - path: "exe/Wrapper.hs"
-      component: "haskell-language-server:exe:haskell-language-server-wrapper"
-
-    - path: "exe/Arguments.hs"
-      component: "haskell-language-server:exe:haskell-language-server-wrapper"
-
-    - path: "test/functional"
-      component: "haskell-language-server:test:func-test"
-
-    - path: "test/utils"
-      component: "haskell-language-server:lib:hls-test-utils"

--- a/test/stackHie.yaml
+++ b/test/stackHie.yaml
@@ -1,10 +1,16 @@
 cradle:
   stack:
-    - path: "src"
-      component: "implicit-hie:lib"
+    - path: "test/Spec.hs"
+      component: "implicit-hie:test:implicit-hie-test"
 
     - path: "app/Main.hs"
       component: "implicit-hie:exe:gen-hie"
 
-    - path: "test"
-      component: "implicit-hie:test:implicit-hie-test"
+    - path: "src/Hie/Cabal/Parser.hs"
+      component: "implicit-hie:lib"
+
+    - path: "src/Hie/Locate.hs"
+      component: "implicit-hie:lib"
+
+    - path: "src/Hie/Yaml.hs"
+      component: "implicit-hie:lib"


### PR DESCRIPTION
There's actually two changes here:

1. Parse using the `cabal-syntax` package. This fixes bugs for descriptors that put source dirs in common stanzas, like [this one](https://github.com/facebookincubator/Glean/blob/main/glean.cabal.in).
2. Generate one hie-bios component per module, instead of one per hs-source-dir. This fixes issues in projects that reuse the same hs-source-dir in multiple Cabal components, like the one linked above does too.