### PR TITLE
A field needs not end with a new line

### DIFF
--- a/src/Hie/Cabal/Parser.hs
+++ b/src/Hie/Cabal/Parser.hs
@@ -110,6 +110,10 @@ parseList i = many (nl <|> sl)
 skipToNextLine :: Parser ()
 skipToNextLine = skipWhile (not . isEndOfLine) >> endOfLine
 
+-- This function may consume no inputs; so 'many skipToNextLineOrEOI' may go into infinite loop.
+skipToNextLineOrEOI :: Parser ()
+skipToNextLineOrEOI = skipWhile (not . isEndOfLine) >> (endOfInput <|> endOfLine)
+
 comment :: Parser ()
 comment = skipMany tabOrSpace >> "--" >> skipToNextLine
 
@@ -133,7 +137,7 @@ field i f p =
     _ <- char ':'
     skipMany tabOrSpace
     p' <- p $ i' + 1
-    skipToNextLine
+    skipToNextLineOrEOI
     pure p'
 
 -- | Skip at least n spaces


### PR DESCRIPTION
This PR changes the behavior of `field` so that it can parse a field that does not end with a new line, addressing #54.

In the latest version, it seems to me that `field` is used only in `extractPkgs`. So, I have only tested `extractPkgs` in REPL. 

It works as expected for my example used in #54. 

```
$ cabal repl 
ghci> parseOnly extractPkgs (Data.Text.pack "packages: proj/*.cabal\n")
Right ["proj/*.cabal"]
ghci> parseOnly extractPkgs (Data.Text.pack "packages: proj/*.cabal")
Right ["proj/*.cabal"]
```

I also confirmed the following behavior is kept unchanged for this commit. 

```
$ cabal repl 
ghci> import Data.Text.IO as T
ghci> T.readFile "./test/cabal.project"  >>= \s -> pure $ parseOnly extractPkgs s
Right ["optics/*.cabal","optics-core/*.cabal","optics-extra/*.cabal","optics-sop/*.cabal","optics-th/*.cabal","optics-vl/*.cabal","indexed-profunctors/*.cabal","template-haskell-optics/*.cabal","metametapost/*.cabal"]
```

I haven't checked how this change affects 0.1.2.7, which I understand is what is called 0.1.4.0 and uses the `field` function in places other than `extractPkgs`.